### PR TITLE
Allow command line arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Build directory
 [Bb]uild/
 
+# IDE directories
+.vscode/
+
 # Compiled Object files
 *.slo
 *.lo

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # IDE directories
 .vscode/
+.vs/
 
 # Compiled Object files
 *.slo

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -15,7 +15,14 @@
                     "${workspaceRoot}"
                 ]
             },
-            "intelliSenseMode": "clang-x64"
+            "intelliSenseMode": "clang-x64",
+            "macFrameworkPath": [
+                "/System/Library/Frameworks",
+                "/Library/Frameworks"
+            ],
+            "compilerPath": "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.31.31103/bin/Hostx64/x64/cl.exe",
+            "cStandard": "c17",
+            "cppStandard": "c++17"
         },
         {
             "name": "Linux",
@@ -32,7 +39,10 @@
                     "${workspaceRoot}"
                 ]
             },
-            "intelliSenseMode": "clang-x64"
+            "intelliSenseMode": "clang-x64",
+            "compilerPath": "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.31.31103/bin/Hostx64/x64/cl.exe",
+            "cStandard": "c17",
+            "cppStandard": "c++17"
         },
         {
             "name": "Win32",
@@ -47,7 +57,10 @@
                     "${workspaceRoot}"
                 ]
             },
-            "intelliSenseMode": "msvc-x64"
+            "intelliSenseMode": "msvc-x64",
+            "compilerPath": "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.31.31103/bin/Hostx64/x64/cl.exe",
+            "cStandard": "c17",
+            "cppStandard": "c++17"
         },
         {
             "name": "KeyPad",
@@ -62,8 +75,11 @@
                     "${workspaceRoot}"
                 ]
             },
-            "intelliSenseMode": "clang-x64"
+            "intelliSenseMode": "clang-x64",
+            "compilerPath": "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.31.31103/bin/Hostx64/x64/cl.exe",
+            "cStandard": "c17",
+            "cppStandard": "c++17"
         }
     ],
-    "version": 2
+    "version": 4
 }

--- a/Code/input_parameter_parser.cpp
+++ b/Code/input_parameter_parser.cpp
@@ -1,0 +1,22 @@
+#include <inputparameterparser.h>
+
+InputParameterParser::InputParameterParser(int& argc, char** argv) {
+    for (int i = 1; i < argc; ++i) {
+        this->_tokens.push_back(string(argv[i]));
+    }
+}
+
+const string& InputParameterParser::getCmdOption(const string& option) const {
+    vector<string>::const_iterator iterator;
+    iterator = find(this->tokens.begin(), this->tokens.end(), option);
+    if (iterator != this->_tokens.end() && ++iterator != this->_tokens.end()) {
+        return *iterator;
+    }
+
+    static const string empty_string("");
+    return empty_string;
+}
+
+bool InputParameterParser::cmdOptionExists(const string& option) const {
+    return find(this->_tokens.begin(), this-_tokens.end(), option) != this->_tokens.end();
+}

--- a/ExampleMappings/linux_example.txt
+++ b/ExampleMappings/linux_example.txt
@@ -1,0 +1,48 @@
+# The below mappings is for mapping a joystick button press to a keyboard key in the Linux OS
+# Joystick Button Codes (using Xbox controller face buttons)
+# ---------------------
+# 0 -> A
+# 1 -> B
+# 2 -> X
+# 3 -> Y
+# 4 -> LEFT_SHOULDER_BUTTON
+# 5 -> RIGHT_SHOULDER_BUTTON
+# 6 -> BACK_BUTTON
+# 7 -> MENU_BUTTON
+# 8 -> HOME_BUTTON
+# 9 -> LEFT_STICK_BUTTON
+# 10 -> RIGHT_STICK_BUTTON
+# 11 -> DPAD_RIGHT
+# 12 -> DPAD_LEFT
+# 13 -> DPAD_UP
+# 14 -> DPAD_DOWN
+# 15 -> LEFT_STICK_LEFT
+# 16 -> LEFT_STICK_UP
+# 17 -> LEFT_STICK_RIGHT
+# 18 -> LEFT_STICK_DOWN
+# NULL means that it isn't mapped
+# ---------------------
+# Linux keyboard codes can be found at https://github.com/torvalds/linux/blob/master/include/uapi/linux/input-event-codes.h
+#
+# This file maps the ABXY to SDAW keyboard keys (in that order), the DPAD directions to the arrow keys,
+# the back button to the spacebar, and the menu button (start button) to the enter key.
+# The left joystick is not mapped to anything (although could map to the arrow keys just like the DPAD)
+0=31
+1=32
+2=30
+3=21
+4=16
+5=18
+6=57
+7=28
+8=NULL
+9=NULL
+10=NULL
+11=106
+12=105
+13=103
+14=108
+15=NULL
+16=NULL
+17=NULL
+18=NULL

--- a/ExampleMappings/linux_example.txt
+++ b/ExampleMappings/linux_example.txt
@@ -1,4 +1,5 @@
-# The below mappings is for mapping a joystick button press to a keyboard key in the Linux OS
+# The below mappings is for mapping a joystick button press to a keyboard key in the Linux OS.
+# The file type should stay as TXT
 # Joystick Button Codes (using Xbox controller face buttons)
 # ---------------------
 # 0 -> A

--- a/Headers/inputparameterparser.h
+++ b/Headers/inputparameterparser.h
@@ -9,7 +9,7 @@ private:
     vector<string> _tokens;
 
 public:
-    InputParser(int& argc, char** argv);
+    InputParameterParser(int& argc, char** argv);
     bool cmdOptionExists(const string& option) const;
     const string& getCmdOption(const string& option) const;
 }

--- a/Headers/inputparameterparser.h
+++ b/Headers/inputparameterparser.h
@@ -1,0 +1,17 @@
+#ifndef INPUTPARAMETERPARSER_H
+#define INPUTPARAMETERPARSER_H
+
+using namespace std;
+
+class InputParameterParser
+{
+private:
+    vector<string> _tokens;
+
+public:
+    InputParser(int& argc, char** argv);
+    bool cmdOptionExists(const string& option) const;
+    const string& getCmdOption(const string& option) const;
+}
+
+#endif

--- a/keypadservice.cpp
+++ b/keypadservice.cpp
@@ -6,6 +6,7 @@
 #include <settings.h>
 #include <keymapping.h>
 #include <keybindconverter.h>
+#include <inputparameterparser.h>
 
 #if PLATFORM_LINUX
 #include <linuxjoystick.h>
@@ -41,13 +42,17 @@ int main (int argc, char** argv) {
 	Keyboard* pKeyboard = NULL;
 	Joystick* pJoystick = NULL;
 	ConsoleLogger logger;
+	InputParameterParser inputParser(argc, argv);
 	setupSignalHandler();
 
 	try {
 		Settings settings(settingsFileLocation.c_str());
 		settings.load();
 
-		std::string fileLocation = settings.getValue("keybindings_location");
+		std::string fileLocation = inputParser.cmdOptionExists("-f")
+			? inputParser.getCmdOption("-f")
+			: settings.getValue("keybindings_location");
+
 		KeyMapping keyMap = buildKeyMap(fileLocation);
 		pKeyboard = createKeyboard(&logger, &settings);
 		pJoystick = createJoystick(&logger, &settings);
@@ -142,7 +147,7 @@ KeyMapping buildKeyMap(std::string fileLocation) {
 
 	std::string line;
 	while (getline(inFile, line)) {
-		if (line.length() == 0) {
+		if (line.length() == 0 || line[0] == '#') {
 			continue;
 		}
 


### PR DESCRIPTION
The computer that I was working on this project on is out of commission and I had been struggling getting the C++ toolkit working on this new machine.  It's been a long time since I've done anything in C++ so I've very rusty.  These changes were done blind so it won't surprise me if I need to tweak things here and there in the PR.

This PR adds the ability to supply the `-f` command parameter to tell the service where the bindings file is.  If one isn't provided the value found in the settings file will be used instead.  I also added an example bindings file along with the code that reads the bindings file to treat the hash `#` character as a line to be ignored so I could add comments to the example file explaining what each number meant and where I found the key codes for the keyboard.